### PR TITLE
Add indentation rule for ending braces

### DIFF
--- a/hyprlang-ts-mode.el
+++ b/hyprlang-ts-mode.el
@@ -82,6 +82,7 @@
 (defvar hyprlang-ts-mode--indent-rules
   ;; Hyprlang indentation rules
   `((hyprlang
+     ((node-is "}") parent 0)
      ((parent-is "section") parent hyprlang-ts-mode-indent-offset)
      ((node-is "section") parent 0)
      ((node-is "comment") parent 0)


### PR DESCRIPTION
I noticed that the indentation for section ending curly braces were a bit off, so this PR:
* adds the `((node-is "}") parent 0)` indentation rule, which makes the closing braces match the indentation level of `parent`


Original:
```
general {
  gaps_in = 5
  gaps_out = 5
  }
```
Fixed:
```
general {
  gaps_in = 5
  gaps_out = 5
}
```