### PR TITLE
Fix `exec` and `source` highlighting

### DIFF
--- a/hyprlang-ts-mode.el
+++ b/hyprlang-ts-mode.el
@@ -46,7 +46,8 @@
     :language hyprlang
     :override t
     :feature exec
-    ((exec) @font-lock-keyword-face)
+    ((exec "exec" @font-lock-keyword-face "=" @font-lock-operator-face)
+     (exec "exec-once" @font-lock-keyword-face "=" @font-lock-operator-face))
 
     :language hyprlang
     :override t

--- a/hyprlang-ts-mode.el
+++ b/hyprlang-ts-mode.el
@@ -50,6 +50,11 @@
 
     :language hyprlang
     :override t
+    :feature source
+    ((source "source" @font-lock-keyword-face "=" @font-lock-operator-face))
+
+    :language hyprlang
+    :override t
     :feature variable
     ((variable) @font-lock-variable-name-face)
 
@@ -76,8 +81,7 @@
     :language hyprlang
     :override t
     :feature mod
-    ((mod) @font-lock-variable-use-face)
-    ))
+    ((mod) @font-lock-variable-use-face)))
 
 (defvar hyprlang-ts-mode--indent-rules
   ;; Hyprlang indentation rules
@@ -109,7 +113,7 @@
   (setq-local font-lock-defaults nil)
   (setq-local treesit-font-lock-feature-list
               '((comment)
-                (section assignment keyword exec declaration)
+                (section assignment keyword exec source declaration)
                 (variable string string_literal number boolean mod)))
 
   ;; set indentation rules


### PR DESCRIPTION
This PR:
* Adds font lock rule for the `source` keyword based on [grammar.json#L200](https://github.com/tree-sitter-grammars/tree-sitter-hyprlang/blob/6858695eba0e63b9e0fceef081d291eb352abce8/src/grammar.json#L200)
* Refactors the `exec` font lock rule, so it matches [grammar.json#L221](https://github.com/tree-sitter-grammars/tree-sitter-hyprlang/blob/6858695eba0e63b9e0fceef081d291eb352abce8/src/grammar.json#L221)
  * _(this also solved a bug I encountered, where comments after `exec` lines were highlighted with `font-lock-keyword-face`)_ 

